### PR TITLE
Adding Humidity and Temperature compensation to SGP40 in preperation for VOC Algorithm 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Usage Example
     import busio
     import adafruit_sgp40
 
-    i2c = busio.I2C(board.SCL, board.SDA)
+    i2c = board.I2C()  # uses board.SCL and board.SDA
     sgp = adafruit_sgp40(i2c)
 
     while True:

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ For humidity compensated raw gas readings, we'll need a secondary sensor such as
     import adafruit_sgp40
     import adafruit_bme280
 
-    i2c = busio.I2C(board.SCL, board.SDA)
+    i2c = board.I2C()  # uses board.SCL and board.SDA
     sgp = adafruit_sgp40.SGP40(i2c)
     bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
 

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,6 @@ For humidity compensated raw gas readings, we'll need a secondary sensor such as
 
     import time
     import board
-    import busio
     import adafruit_sgp40
     import adafruit_bme280
 

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,6 @@ Usage Example
 
     import time
     import board
-    import busio
     import adafruit_sgp40
 
     i2c = board.I2C()  # uses board.SCL and board.SDA

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ Usage Example
     import time
     import board
     import busio
+    import adafruit_sgp40
 
     i2c = busio.I2C(board.SCL, board.SDA)
     sgp = adafruit_sgp40(i2c)
@@ -73,6 +74,29 @@ Usage Example
         print("Measurement: ", sgp.raw)
         print("")
         sleep(1)
+
+For humidity compensated raw gas readings, we'll need a secondary sensor such as the bme280
+
+.. code-block:: python3
+
+    import time
+    import board
+    import busio
+    import adafruit_sgp40
+    import adafruit_bme280
+
+    i2c = busio.I2C(board.SCL, board.SDA)
+    sgp = adafruit_sgp40.SGP40(i2c)
+    bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
+
+    while True:
+        temperature = bme280.temperature
+        humidity = bme280.relative_humidity
+        compensated_raw_gas = sgp.measure_raw(temperature = temperature, relative_humidity = humidity)
+        print(compensated_raw_gas)
+        print("")
+        time.sleep(1)
+
 
 
 Contributing

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -217,6 +217,12 @@ class SGP40:
         A humidity and temperature compensated raw gas value which helps
         address fluctuations in readings due to changing humidity.
 
+
+        :param float temperature: The temperature in degrees Celsius, defaults
+                                     to :const:`25`
+        :param float relative_humidity: The relative humidity in percentage, defaults
+                                     to :const:`50`
+
         The raw gas value adjusted for the current temperature (c) and humidity (%)
         """
         # recycle a single buffer

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -37,7 +37,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SGP40.git"
 
 _WORD_LEN = 2
 # no point in generating this each time
-_READ_CMD = [0x26, 0x0F, 0x7F, 0xFF, 0x8F, 0x66, 0x66, 0x93] # Generated from temp 25c, humidity 49.999%
+_READ_CMD = [0x26, 0x0F, 0x80, 0x00, 0xA2, 0x66, 0x66, 0x93] # Generated from temp 25c, humidity 49.999%
 
 
 class SGP40:

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -26,7 +26,6 @@ Implementation Notes
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
 
-
  * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 
 """

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -173,18 +173,11 @@ class SGP40:
 
         return readdata_buffer
 
-    @staticmethod
-    def _check_crc8(crc_buffer, crc_value):
-        crc = 0xFF
-        for byte in crc_buffer:
-            crc ^= byte
-            for _ in range(8):
-                if crc & 0x80:
-                    crc = (crc << 1) ^ 0x31
-                else:
-                    crc = crc << 1
-        return crc_value == (crc & 0xFF)  # check against the bottom 8 bits
 
+    def _check_crc8(self, crc_buffer, crc_value):
+        return crc_value == self._generate_crc(crc_buffer)
+
+    @staticmethod
     def _generate_crc(crc_buffer):
         crc = 0xFF
         for byte in crc_buffer:

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -97,7 +97,7 @@ class SGP40:
 
 
     .. note::
-        The operational range of temperatures for the SGP40 is -10 to 50 degrees C
+        The operational range of temperatures for the SGP40 is -10 to 50 degrees Celsius
         and the operational range of relative humidity for the SGP40 is 0 to 90 %
         (assuming that humidity is non-condensing).
 

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -83,7 +83,7 @@ class SGP40:
 
         Now you have access to the raw gas value using the :attr:`raw` attribute.
         And with a temperature and humidity value, you can access the class function
-        `sgp.measure_raw` for a humidity compensated raw reading
+        :meth:`measure_raw` for a humidity compensated raw reading
 
         .. code-block:: python
 

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -72,7 +72,7 @@ class SGP40:
             # If you have a temperature sensor, like the bme280, import that here as well
             # import adafruit_bme280
 
-        Once this is done you can define your `busio.I2C` object and define your sensor object
+        Once this is done you can define your `board.I2C` object and define your sensor object
 
         .. code-block:: python
 

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -27,6 +27,8 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 
 
+ * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
+
 """
 from time import sleep
 from struct import unpack_from

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -17,6 +17,9 @@ Implementation Notes
 **Hardware:**
 
 * Adafruit SGP40 Air Quality Sensor Breakout - VOC Index <https://www.adafruit.com/product/4829>
+* In order to use the `measure_raw` function, a temperature and humidity sensor which
+  updates at at least 1Hz is needed (BME280, BME688, SHT31-D, SHT40, etc. For more, see:
+  https://www.adafruit.com/category/66)
 
 **Software and Dependencies:**
 
@@ -25,7 +28,6 @@ Implementation Notes
 
 
  * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
- * Adafruit's Register library: https://github.com/adafruit/Adafruit_CircuitPython_Register
 
 """
 from time import sleep
@@ -51,7 +53,7 @@ _READ_CMD = [
 
 class SGP40:
     """
-    Class to use the SGP40 Ambient Light and UV sensor
+    Class to use the SGP40 Air Quality Sensor Breakout
 
     :param ~busio.I2C i2c: The I2C bus the SGP40 is connected to.
     :param int address: The I2C address of the device. Defaults to :const:`0x59`
@@ -67,6 +69,8 @@ class SGP40:
             import busio
             import board
             import adafruit_sgp40
+            # If you have a temperature sensor, like the bme280, import that here as well
+            # import adafruit_bme280
 
         Once this is done you can define your `busio.I2C` object and define your sensor object
 
@@ -74,13 +78,36 @@ class SGP40:
 
             i2c = busio.I2C(board.SCL, board.SDA)
             sgp = adafruit_sgp40.SGP40(i2c)
+            # And if you have a temp/humidity sensor, define the sensor here as well
+            # bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
 
-        Now you have access to the raw gas value using the :attr:`raw` attribute
+        Now you have access to the raw gas value using the :attr:`raw` attribute.
+        And with a temperature and humidity value, you can access the class function
+        `sgp.measure_raw` for a humidity compensated raw reading
 
         .. code-block:: python
 
             raw_gas_value = sgp.raw
+            # Lets quickly grab the humidity and temperature
+            # temperature = bme280.temperature
+            # humidity = bme280.relative_humidity
+            # compensated_raw_gas = sgp.measure_raw(
+            # temperature = temperature, relative_humidity = humidity)
 
+
+
+    .. note::
+        The operational range of temperatures for the SGP40 is -10 to 50 degrees C
+        and the operational range of relative humidity for the SGP40 is 0 to 90 %
+        (assuming that humidity is non-condensing).
+
+        Humidity compensation is further optimized for a subset of the temperature
+        and relative humidity readings. See Figure 3 of the Sensirion datasheet for
+        the SGP40. At 25 deg C, the optimal range for relative humidity is 8% to 90%.
+        At 50% relative humidity, the optimal range for temperature is -7 to 42 deg C.
+
+        Prolonged exposures outside of these ranges may reduce sensor performance, and
+        the sensor must not be exposed towards condensing conditions at any time.
 
     """
 
@@ -128,9 +155,47 @@ class SGP40:
         try:
             self._read_word_from_command(delay_ms=50)
         except OSError:
-            # print("\tGot expected OSError from reset")
+            # Got expected OSError from reset
             pass
         sleep(1)
+
+    @staticmethod
+    def _temp_c_to_ticks(temperature):
+        """
+        Converts Temperature in Celsius to 'ticks' which are an input parameter
+        the sgp40 can use
+
+        Temperature to Ticks : From SGP40 Datasheet Table 10
+        temp (C)    | Hex Code (Check Sum/CRC Hex Code)
+            25      | 0x6666   (CRC 0x93)
+            -45     | 0x0000   (CRC 0x81)
+            130     | 0xFFFF   (CRC 0xAC)
+
+        """
+        temp_ticks = int(((temperature + 45) * 65535) / 175) & 0xFFFF
+        least_sig_temp_ticks = temp_ticks & 0xFF
+        most_sig_temp_ticks = (temp_ticks >> 8) & 0xFF
+
+        return [most_sig_temp_ticks, least_sig_temp_ticks]
+
+    @staticmethod
+    def _relative_humidity_to_ticks(humidity):
+        """
+        Converts Relative Humidity in % to 'ticks' which are  an input parameter
+        the sgp40 can use
+
+        Relative Humidity to Ticks : From SGP40 Datasheet Table 10
+        Humidity (%) | Hex Code (Check Sum/CRC Hex Code)
+            50       | 0x8000   (CRC 0xA2)
+            0        | 0x0000   (CRC 0x81)
+            100      | 0xFFFF   (CRC 0xAC)
+
+        """
+        humidity_ticks = int((humidity * 65535) / 100 + 0.5) & 0xFFFF
+        least_sig_rhumidity_ticks = humidity_ticks & 0xFF
+        most_sig_rhumidity_ticks = (humidity_ticks >> 8) & 0xFF
+
+        return [most_sig_rhumidity_ticks, least_sig_rhumidity_ticks]
 
     @property
     def raw(self):
@@ -140,6 +205,23 @@ class SGP40:
         read_value = self._read_word_from_command(delay_ms=250)
         self._command_buffer = bytearray(2)
         return read_value[0]
+
+    def measure_raw(self, temperature=25, relative_humidity=50):
+        """
+        A humidity and temperature compensated raw gas value which helps
+        address fluctuations in readings due to changing humidity.
+
+        The raw gas value adjusted for the current temperature (c) and humidity (%)
+        """
+        # recycle a single buffer
+        _compensated_read_cmd = [0x26, 0x0F]
+        humidity_ticks = self._relative_humidity_to_ticks(relative_humidity)
+        humidity_ticks.append(self._generate_crc(humidity_ticks))
+        temp_ticks = self._temp_c_to_ticks(temperature)
+        temp_ticks.append(self._generate_crc(temp_ticks))
+        _cmd = _compensated_read_cmd + humidity_ticks + temp_ticks
+        self._measure_command = bytearray(_cmd)
+        return self.raw
 
     def _read_word_from_command(
         self,
@@ -172,9 +254,6 @@ class SGP40:
         with self.i2c_device as i2c:
             i2c.readinto(replybuffer, end=replylen)
 
-        # print("Buffer:")
-        # print(["0x{:02X}".format(i) for i in replybuffer])
-
         for i in range(0, replylen, 3):
             if not self._check_crc8(replybuffer[i : i + 2], replybuffer[i + 2]):
                 raise RuntimeError("CRC check failed while reading data")
@@ -183,59 +262,22 @@ class SGP40:
         return readdata_buffer
 
     def _check_crc8(self, crc_buffer, crc_value):
+        """
+        Checks that the 8 bit CRC Checksum value from the sensor matches the
+        received data
+        """
         return crc_value == self._generate_crc(crc_buffer)
 
     @staticmethod
-    def _temp_c_to_ticks(temperature):
-        """
-        tests : From SGP40 Datasheet Table 10
-        temp (C)    | Hex Code (Check Sum/CRC Hex Code)
-            25      | 0x6666   (CRC 0x93)
-            -45     | 0x0000   (CRC 0x81)
-            130     | 0xFFFF   (CRC 0xAC)
-
-        """
-        temp_ticks = int(((temperature + 45) * 65535) / 175) & 0xFFFF
-        least_sig_temp_ticks = temp_ticks & 0xFF
-        most_sig_temp_ticks = (temp_ticks >> 8) & 0xFF
-
-        return [most_sig_temp_ticks, least_sig_temp_ticks]
-
-    @staticmethod
-    def _relative_humidity_to_ticks(humidity):
-        """
-        tests : From SGP40 Datasheet Table 10
-        Humidity (%) | Hex Code (Check Sum/CRC Hex Code)
-            50       | 0x8000   (CRC 0xA2)
-            0        | 0x0000   (CRC 0x81)
-            100      | 0xFFFF   (CRC 0xAC)
-
-        """
-        humidity_ticks = int((humidity * 65535) / 100 + 0.5) & 0xFFFF
-        least_sig_rhumidity_ticks = humidity_ticks & 0xFF
-        most_sig_rhumidity_ticks = (humidity_ticks >> 8) & 0xFF
-
-        return [most_sig_rhumidity_ticks, least_sig_rhumidity_ticks]
-
-    def measure_raw(self, temperature=25, relative_humidity=50):
-        """
-        The raw gas value adjusted for the current temperature (c) and humidity (%)
-        """
-        # recycle a single buffer
-        _compensated_read_cmd = [0x26, 0x0F]
-        humidity_ticks = self._relative_humidity_to_ticks(relative_humidity)
-        humidity_ticks.append(self._generate_crc(humidity_ticks))
-        temp_ticks = self._temp_c_to_ticks(temperature)
-        temp_ticks.append(self._generate_crc(temp_ticks))
-        _cmd = _compensated_read_cmd + humidity_ticks + temp_ticks
-        self._measure_command = bytearray(_cmd)
-        # print(self._command_buffer)
-        # read_value = self._read_word_from_command(delay_ms=250)
-        # self._command_buffer = bytearray(2)
-        return self.raw
-
-    @staticmethod
     def _generate_crc(crc_buffer):
+        """
+        Generates an 8 bit CRC Checksum from the input buffer.
+
+        This checksum algorithm is outlined in Table 7 of the SGP40 datasheet.
+
+        Checksums are only generated for 2-byte data packets. Command codes already
+        contain 3 bits of CRC and therefore do not need an added checksum.
+        """
         crc = 0xFF
         for byte in crc_buffer:
             crc ^= byte

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -76,7 +76,7 @@ class SGP40:
 
         .. code-block:: python
 
-            i2c = busio.I2C(board.SCL, board.SDA)
+            i2c = board.I2C()  # uses board.SCL and board.SDA
             sgp = adafruit_sgp40.SGP40(i2c)
             # And if you have a temp/humidity sensor, define the sensor here as well
             # bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -27,8 +27,6 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 
 
- * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
-
 """
 from time import sleep
 from struct import unpack_from
@@ -55,7 +53,6 @@ class SGP40:
     """
     Class to use the SGP40 Air Quality Sensor Breakout
 
-    :param ~busio.I2C i2c: The I2C bus the SGP40 is connected to.
     :param int address: The I2C address of the device. Defaults to :const:`0x59`
 
 
@@ -66,7 +63,6 @@ class SGP40:
 
         .. code-block:: python
 
-            import busio
             import board
             import adafruit_sgp40
             # If you have a temperature sensor, like the bme280, import that here as well

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -103,7 +103,7 @@ class SGP40:
 
         Humidity compensation is further optimized for a subset of the temperature
         and relative humidity readings. See Figure 3 of the Sensirion datasheet for
-        the SGP40. At 25 deg C, the optimal range for relative humidity is 8% to 90%.
+        the SGP40. At 25 degrees Celsius, the optimal range for relative humidity is 8% to 90%.
         At 50% relative humidity, the optimal range for temperature is -7 to 42 deg C.
 
         Prolonged exposures outside of these ranges may reduce sensor performance, and

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -104,7 +104,7 @@ class SGP40:
         Humidity compensation is further optimized for a subset of the temperature
         and relative humidity readings. See Figure 3 of the Sensirion datasheet for
         the SGP40. At 25 degrees Celsius, the optimal range for relative humidity is 8% to 90%.
-        At 50% relative humidity, the optimal range for temperature is -7 to 42 deg C.
+        At 50% relative humidity, the optimal range for temperature is -7 to 42 degrees Celsius.
 
         Prolonged exposures outside of these ranges may reduce sensor performance, and
         the sensor must not be exposed towards condensing conditions at any time.

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -91,7 +91,7 @@ class SGP40:
             # Lets quickly grab the humidity and temperature
             # temperature = bme280.temperature
             # humidity = bme280.relative_humidity
-            # compensated_raw_gas = sgp.measure_raw(
+            # compensated_raw_gas = sgp.measure_raw(temperature=temperature, relative_humidity=humidity)
             # temperature = temperature, relative_humidity = humidity)
 
 

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -91,7 +91,8 @@ class SGP40:
             # Lets quickly grab the humidity and temperature
             # temperature = bme280.temperature
             # humidity = bme280.relative_humidity
-            # compensated_raw_gas = sgp.measure_raw(temperature=temperature, relative_humidity=humidity)
+            # compensated_raw_gas = sgp.measure_raw(temperature=temperature,
+            # relative_humidity=humidity)
             # temperature = temperature, relative_humidity = humidity)
 
 
@@ -108,6 +109,11 @@ class SGP40:
 
         Prolonged exposures outside of these ranges may reduce sensor performance, and
         the sensor must not be exposed towards condensing conditions at any time.
+
+        For more information see:
+        https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9_Gas_Sensors/Datasheets/Sensirion_Gas_Sensors_Datasheet_SGP40.pdf
+        and
+        https://learn.adafruit.com/adafruit-sgp40
 
     """
 
@@ -160,7 +166,7 @@ class SGP40:
         sleep(1)
 
     @staticmethod
-    def _temp_c_to_ticks(temperature):
+    def _celsius_to_ticks(temperature):
         """
         Converts Temperature in Celsius to 'ticks' which are an input parameter
         the sgp40 can use
@@ -217,7 +223,7 @@ class SGP40:
         _compensated_read_cmd = [0x26, 0x0F]
         humidity_ticks = self._relative_humidity_to_ticks(relative_humidity)
         humidity_ticks.append(self._generate_crc(humidity_ticks))
-        temp_ticks = self._temp_c_to_ticks(temperature)
+        temp_ticks = self._celsius_to_ticks(temperature)
         temp_ticks.append(self._generate_crc(temp_ticks))
         _cmd = _compensated_read_cmd + humidity_ticks + temp_ticks
         self._measure_command = bytearray(_cmd)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,10 +34,6 @@ intersphinx_mapping = {
         "https://circuitpython.readthedocs.io/projects/busdevice/en/latest/",
         None,
     ),
-    "Register": (
-        "https://circuitpython.readthedocs.io/projects/register/en/latest/",
-        None,
-    ),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
 }
 

--- a/examples/sgp40_simpletest.py
+++ b/examples/sgp40_simpletest.py
@@ -3,13 +3,12 @@
 # SPDX-License-Identifier: Unlicense
 import time
 import board
-import busio
 import adafruit_sgp40
 
 # If you have a temperature sensor, like the bme280, import that here as well
 # import adafruit_bme280
 
-i2c = busio.I2C(board.SCL, board.SDA)
+i2c = board.I2C()  # uses board.SCL and board.SDA
 sgp = adafruit_sgp40.SGP40(i2c)
 # And if you have a temp/humidity sensor, define the sensor here as well
 # bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)

--- a/examples/sgp40_simpletest.py
+++ b/examples/sgp40_simpletest.py
@@ -6,10 +6,19 @@ import board
 import busio
 import adafruit_sgp40
 
+# If you have a temperature sensor, like the bme280, import that here as well
+# import adafruit_bme280
+
 i2c = busio.I2C(board.SCL, board.SDA)
 sgp = adafruit_sgp40.SGP40(i2c)
+# And if you have a temp/humidity sensor, define the sensor here as well
+# bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
 
 while True:
     print("Raw Gas: ", sgp.raw)
+    # Lets quickly grab the humidity and temperature
+    # temperature = bme280.temperature
+    # humidity = bme280.relative_humidity
+    # compensated_raw_gas = sgp.measure_raw(temperature = temperature, relative_humidity = humidity)
     print("")
     time.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@
 
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
-adafruit-circuitpython-register

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     install_requires=[
         "Adafruit-Blinka",
         "adafruit-circuitpython-busdevice",
-        "adafruit-circuitpython-register",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
In short this lets a user provide temperature (in C) and humidity (in percentage) to the SGP40 for a humidity compensated raw value reading.

Humidity compensation is necessary for the VOC algorithm mentioned in #2 and this should help implement the VOC algorithm over the next week or two. 

There is a spelling correction and I adjusted the _READ_CMD byte array to match the provided byte array in the SGP40 data sheet (table 9). This shouldn't have a large impact on anyone's code since the byte array was generated used input humidity of 49.999%, and the datasheet example used an input of 50%.

The checksum `_check_crc8` was adjusted to call a new function--generate_crc which is basically the original _check_crc8 with the adjustment that it returns the crc byte.

Temperature and Humidity are converted to their 'tick' value according to the equation in the datasheet.

And `measure_raw` takes in the temperature and humidity, converts them to ticks, then generates a measure command hex array. Once the measure_command is generated it calls raw to handle the communication. 
