### PR TITLE
Convert _READ_CMD to bytes to work with memview (Blinka)

### DIFF
--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -38,16 +38,18 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SGP40.git"
 
 _WORD_LEN = 2
 # no point in generating this each time
-_READ_CMD = [
-    0x26,
-    0x0F,
-    0x80,
-    0x00,
-    0xA2,
-    0x66,
-    0x66,
-    0x93,
-]  # Generated from temp 25c, humidity 50%
+_READ_CMD = bytes(
+    [
+        0x26,
+        0x0F,
+        0x80,
+        0x00,
+        0xA2,
+        0x66,
+        0x66,
+        0x93,
+    ]
+)  # Generated from temp 25c, humidity 50%
 
 
 class SGP40:

--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -37,19 +37,10 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SGP40.git"
 
 _WORD_LEN = 2
+
 # no point in generating this each time
-_READ_CMD = bytes(
-    [
-        0x26,
-        0x0F,
-        0x80,
-        0x00,
-        0xA2,
-        0x66,
-        0x66,
-        0x93,
-    ]
-)  # Generated from temp 25c, humidity 50%
+# Generated from temp 25c, humidity 50%
+_READ_CMD = b"\x26\x0F\x80\x00\xA2\x66\x66\x93"
 
 
 class SGP40:


### PR DESCRIPTION
For #5. This is a Blinka only issue. Simple fix, just convert the list to bytes.

Tested with FT232H:
```python
$ python3
Python 3.8.10 (default, Jun  2 2021, 10:49:15) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> import adafruit_sgp40
>>> sgp = adafruit_sgp40.SGP40(board.I2C())
>>> sgp.raw
2
>>>  
```