### PR TITLE
Update _reset for MCP2221

### DIFF
--- a/adafruit_sgp40.py
+++ b/adafruit_sgp40.py
@@ -150,8 +150,9 @@ class SGP40:
         self._command_buffer[1] = 0x06
         try:
             self._read_word_from_command(delay_ms=50)
-        except OSError:
+        except (OSError, RuntimeError):
             # Got expected OSError from reset
+            # or RuntimeError on some Blinka setups
             pass
         sleep(1)
 


### PR DESCRIPTION
For #7. 

Basically just adding exception type that gets thrown for MCP2221 case.

```python
(blinka) hellokitty@bench:~/repos/Adafruit_CircuitPython_SGP40$ python3
Python 3.8.10 (default, Jun  2 2021, 10:49:15) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> import adafruit_sgp40
>>> sgp = adafruit_sgp40.SGP40(board.I2C())
>>> sgp.raw
2
>>> sgp.raw
24895
>>> sgp.raw
25563
>>> 
```